### PR TITLE
fix: download artifact v3 no longer works

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -190,7 +190,7 @@ jobs:
     steps:
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildkit
           path: ${{ env.DESTDIR }}

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -109,7 +109,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Download dockerd
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dockerd
           path: ./build/

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -128,13 +128,13 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildkit-freebsd-amd64
           path: ${{ env.DESTDIR }}
       -
         name: Cache Vagrant boxes
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ hashFiles('hack/Vagrantfile.freebsd13') }}


### PR DESCRIPTION
fix: download artifact v3 no longer works

- saw issue on scheduled builds in main.