### PR TITLE
solver: explain cache misses and expose per-vertex cache keys

### DIFF
--- a/solver/edge.go
+++ b/solver/edge.go
@@ -2,6 +2,8 @@ package solver
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,6 +53,7 @@ type edge struct {
 	cacheMapDigests    []digest.Digest
 	execReq            pipe.Receiver
 	execCacheLoad      bool
+	cacheMissReason    string
 	err                error
 	cacheRecords       map[string]*CacheRecord
 	cacheRecordsLoaded map[string]struct{}
@@ -109,6 +112,10 @@ type edgeState struct {
 	result   *SharedCachedResult
 	cacheMap *CacheMap
 	keys     []ExportableCacheKey
+	// cached reports whether result was loaded from cache rather than executed.
+	// It propagates to dependant edges so they can explain their own cache
+	// misses at the cache-break boundary (see calcCacheMissReason).
+	cached bool
 }
 
 type edgeRequest struct {
@@ -457,6 +464,7 @@ func (e *edge) processUpdate(upt pipe.Receiver) (depChanged bool) {
 		} else {
 			e.result = NewSharedCachedResult(upt.Status().Value.(CachedResult))
 			e.state = edgeStatusComplete
+			e.cached = e.execCacheLoad
 		}
 		return true
 	}
@@ -871,11 +879,71 @@ func (e *edge) execIfPossible(f *pipeFactory) bool {
 			e.postpone(f)
 			return true
 		}
+		e.cacheMissReason = e.calcCacheMissReason()
 		e.execReq = f.NewFuncRequest(e.execOp)
 		e.execCacheLoad = false
 		return true
 	}
 	return false
+}
+
+const cacheMissPrefix = "cache miss: "
+
+// calcCacheMissReason returns a short, human-readable explanation of why this
+// edge must be executed instead of loaded from cache. It only speaks up at the
+// cache-break boundary — a step that runs even though at least one of its
+// inputs was a cache hit — so a cold (sub)build, where a miss line on every step
+// would be noise, stays quiet (returns "").
+//
+// The reason is derived from reliable local state only: whether the cache was
+// explicitly disabled, and per-input cache-hit status (dep.cached). A cache-hit
+// input has a bit-identical prior result, so it cannot itself be the thing that
+// changed — which lets us attribute the miss without guessing. We deliberately
+// do not try to distinguish "this step's definition changed" from "this exact
+// combination of cached inputs was never built before": BuildKit's cache is
+// content-addressed over (definition digest + every input key), so the two are
+// indistinguishable from an edge's local view.
+//
+// Called from execIfPossible, i.e. under the scheduler, so reading dep state is
+// safe.
+func (e *edge) calcCacheMissReason() string {
+	if e.op.IgnoreCache() {
+		return cacheMissPrefix + "cache disabled for this step (--no-cache)"
+	}
+
+	var cached, rebuilt []string
+	for _, d := range e.deps {
+		if d.cached {
+			cached = append(cached, e.depName(d))
+		} else {
+			rebuilt = append(rebuilt, e.depName(d))
+		}
+	}
+
+	// Boundary gate: only explain the miss when something upstream was cached.
+	if len(cached) == 0 {
+		return ""
+	}
+
+	if len(rebuilt) > 0 {
+		// The step ran because these inputs were (re)built upstream.
+		return cacheMissPrefix + "rebuilt input(s): " + strings.Join(rebuilt, ", ")
+	}
+
+	// Every input came from cache, yet this step has no matching cached result.
+	return cacheMissPrefix + "all inputs cached but no matching result for this step (its definition changed, or this input combination is new)"
+}
+
+// depName returns a human-readable name for a dependency input, falling back to
+// the input index when the input vertex is unnamed.
+func (e *edge) depName(d *dep) string {
+	inputs := e.edge.Vertex.Inputs()
+	if int(d.index) < len(inputs) {
+		if name := inputs[int(d.index)].Vertex.Name(); name != "" {
+			return name
+		}
+	}
+	return fmt.Sprintf("input %d", int(d.index))
 }
 
 // postpone delays exec to next unpark invocation if we have unprocessed keys
@@ -908,7 +976,7 @@ func (e *edge) loadCache(ctx context.Context) (interface{}, error) {
 // execOp creates a request to execute the vertex operation
 func (e *edge) execOp(ctx context.Context) (interface{}, error) {
 	cacheKeys, inputs := e.commitOptions()
-	results, subExporters, err := e.op.Exec(ctx, toResultSlice(inputs))
+	results, subExporters, err := e.op.Exec(ctx, toResultSlice(inputs), e.cacheMissReason)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/solver/inconsistent_graph_state_error_tracker.go
+++ b/solver/inconsistent_graph_state_error_tracker.go
@@ -5,6 +5,7 @@ package solver
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	digest "github.com/opencontainers/go-digest"
@@ -18,7 +19,12 @@ type dgstTrackerItem struct {
 	seen   time.Time
 }
 
+// dgstTracker is a fixed-size ring buffer of recent vertex actions, used to
+// reconstruct context for "inconsistent graph state" errors. The instance is a
+// package-level global written from concurrent vertex loads, so all access is
+// guarded by mu.
 type dgstTracker struct {
+	mu      sync.Mutex
 	head    int
 	records []dgstTrackerItem
 }
@@ -31,6 +37,8 @@ func newDgstTracker() *dgstTracker {
 }
 
 func (d *dgstTracker) add(dgst digest.Digest, action string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.head++
 	if d.head >= len(d.records) {
 		d.head = 0
@@ -41,6 +49,8 @@ func (d *dgstTracker) add(dgst digest.Digest, action string) {
 }
 
 func (d *dgstTracker) String() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	var sb strings.Builder
 
 	for i := d.head; i >= 0; i-- {

--- a/solver/jobs.go
+++ b/solver/jobs.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -701,7 +702,7 @@ type cacheMapResp struct {
 type activeOp interface {
 	CacheMap(context.Context, int) (*cacheMapResp, error)
 	LoadCache(ctx context.Context, rec *CacheRecord) (Result, error)
-	Exec(ctx context.Context, inputs []Result) (outputs []Result, exporters []ExportableCacheKey, err error)
+	Exec(ctx context.Context, inputs []Result, cacheMissReason string) (outputs []Result, exporters []ExportableCacheKey, err error)
 	IgnoreCache() bool
 	Cache() CacheManager
 	CalcSlowCache(context.Context, Index, PreprocessFunc, ResultBasedCacheFunc, Result) (digest.Digest, error)
@@ -766,6 +767,31 @@ func (c cacheWithCacheOpts) Records(ctx context.Context, ck *CacheKey) ([]*Cache
 	return c.CacheManager.Records(withAncestorCacheOpts(ctx, c.st), ck)
 }
 
+// emitCacheKeyDebug writes the vertex→cache-key-digest join as a log line when
+// BUILDKIT_CACHE_KEY_DEBUG is set. The op cache-map digest is the authoritative
+// key into the --save-cache-debug plaintext store; emitting it per vertex lets
+// tooling map a build step to its digest (something the content-addressed cache
+// never persists) and diff/look it up to explain cache misses. Called after
+// notifyStarted so the vertex's Started event is seen first.
+func (s *sharedOp) emitCacheKeyDebug() {
+	if !cacheKeyDebug || len(s.cacheRes) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(s.cacheRes))
+	for _, cm := range s.cacheRes {
+		if cm != nil {
+			keys = append(keys, cm.Digest.String())
+		}
+	}
+	if len(keys) == 0 {
+		return
+	}
+	s.st.mpw.Write(identity.NewID(), client.VertexLog{
+		Stream: 2, // stderr
+		Data:   []byte("[cache-key] vtx=" + s.st.vtx.Digest().String() + " op=" + strings.Join(keys, ",") + "\n"),
+	})
+}
+
 func (s *sharedOp) LoadCache(ctx context.Context, rec *CacheRecord) (Result, error) {
 	ctx = progress.WithProgress(ctx, s.st.mpw)
 	if s.st.mspan.Span != nil {
@@ -774,6 +800,7 @@ func (s *sharedOp) LoadCache(ctx context.Context, rec *CacheRecord) (Result, err
 	// no cache hit. start evaluating the node
 	span, ctx := tracing.StartSpan(ctx, "load cache: "+s.st.vtx.Name(), trace.WithAttributes(attribute.String("vertex", s.st.vtx.Digest().String())))
 	notifyCompleted := notifyStarted(ctx, &s.st.clientVertex, true)
+	s.emitCacheKeyDebug()
 	res, err := s.Cache().Load(withAncestorCacheOpts(ctx, s.st), rec)
 	tracing.FinishWithError(span, err)
 	notifyCompleted(err, true)
@@ -933,7 +960,7 @@ func (s *sharedOp) CacheMap(ctx context.Context, index int) (resp *cacheMapResp,
 	return &cacheMapResp{CacheMap: res[index], complete: s.cacheDone}, nil
 }
 
-func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result, exporters []ExportableCacheKey, err error) {
+func (s *sharedOp) Exec(ctx context.Context, inputs []Result, cacheMissReason string) (outputs []Result, exporters []ExportableCacheKey, err error) {
 	defer func() {
 		err = errdefs.WithOp(err, s.st.vtx.Sys())
 		err = errdefs.WrapVertex(err, s.st.origDigest)
@@ -969,6 +996,19 @@ func (s *sharedOp) Exec(ctx context.Context, inputs []Result) (outputs []Result,
 			tracing.FinishWithError(span, retErr)
 			notifyCompleted(retErr, false)
 		}()
+
+		s.emitCacheKeyDebug()
+
+		// Surface why this step is not a cache hit as a vertex log line. mpw
+		// carries the "vertex" metadata (set in loadUnlocked), so this is
+		// attributed to the right vertex and printed like any other step output.
+		// Emitted after notifyStarted so the vertex's Started event is seen first.
+		if cacheMissReason != "" {
+			s.st.mpw.Write(identity.NewID(), client.VertexLog{
+				Stream: 2, // stderr
+				Data:   []byte(cacheMissReason + "\n"),
+			})
+		}
 
 		res, err := op.Exec(ctx, s.st, inputs)
 		complete := true

--- a/solver/scheduler.go
+++ b/solver/scheduler.go
@@ -15,9 +15,20 @@ import (
 
 var debugScheduler = false // TODO: replace with logs in build trace
 
+// cacheKeyDebug, when enabled via BUILDKIT_CACHE_KEY_DEBUG=1, makes every vertex
+// emit its authoritative cache-key digest(s) as a log line. This is the
+// vertex→digest join that the persisted cache deliberately does not store (the
+// cache is content-addressed and vertex-agnostic). With it, external tooling can
+// diff cache keys run-over-run and reverse-look-up the plaintext inputs via the
+// --save-cache-debug API to explain why a step missed cache.
+var cacheKeyDebug = false
+
 func init() {
 	if os.Getenv("BUILDKIT_SCHEDULER_DEBUG") == "1" {
 		debugScheduler = true
+	}
+	if os.Getenv("BUILDKIT_CACHE_KEY_DEBUG") == "1" {
+		cacheKeyDebug = true
 	}
 }
 

--- a/solver/scheduler_test.go
+++ b/solver/scheduler_test.go
@@ -7,10 +7,12 @@ import (
 	"math"
 	"math/rand"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	digest "github.com/opencontainers/go-digest"
@@ -3852,6 +3854,161 @@ func blockingFuncion(i int) func(context.Context) error {
 		<-block
 		return nil
 	}
+}
+
+// buildCapturingLogs builds g under a fresh job, capturing per-vertex log lines
+// (client.VertexLog) keyed by vertex digest. The MultiReader buffers and replays
+// all progress, so capture is independent of goroutine timing.
+func buildCapturingLogs(ctx context.Context, t *testing.T, s *Solver, jobID string, g Edge) (string, map[digest.Digest]string) {
+	t.Helper()
+	j, err := s.NewJob(jobID)
+	require.NoError(t, err)
+
+	statusCtx, cancel := context.WithCancel(ctx)
+	logs := map[digest.Digest]string{}
+	var mu sync.Mutex
+	ch := make(chan *client.SolveStatus)
+	done := make(chan struct{})
+	go func() { _ = j.Status(statusCtx, true, ch) }()
+	go func() {
+		defer close(done)
+		for ss := range ch {
+			mu.Lock()
+			for _, l := range ss.Logs {
+				logs[l.Vertex] += string(l.Data)
+			}
+			mu.Unlock()
+		}
+	}()
+
+	res, err := j.Build(ctx, g)
+	require.NoError(t, err)
+	val := unwrap(res)
+
+	// All progress is buffered in the MultiReader by the time Build returns;
+	// give the in-memory stream a moment to drain to our reader, then stop it.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	<-done
+	require.NoError(t, j.Discard())
+
+	mu.Lock()
+	defer mu.Unlock()
+	out := make(map[digest.Digest]string, len(logs))
+	for k, v := range logs {
+		out[k] = v
+	}
+	return val, out
+}
+
+// TestCacheMissReason verifies that a step which executes despite at least one
+// of its inputs being a cache hit emits a human-readable cache-miss reason as a
+// vertex log line, while a cold build (nothing upstream cached) stays quiet.
+func TestCacheMissReason(t *testing.T) {
+	t.Parallel()
+	ctx := context.TODO()
+
+	t.Run("cold build is quiet, definition change is explained", func(t *testing.T) {
+		t.Parallel()
+		s := NewSolver(SolverOpt{ResolveOpFunc: testOpResolver})
+		defer s.Close()
+
+		// Cold build: parent <- child, both execute. No input was cached, so
+		// neither step should report a cache miss.
+		g0 := Edge{Vertex: vtx(vtxOpt{
+			name: "parent0", cacheKeySeed: "p", value: "pv",
+			inputs: []Edge{{Vertex: vtx(vtxOpt{name: "child0", cacheKeySeed: "c", value: "cv"})}},
+		})}
+		_, logs0 := buildCapturingLogs(ctx, t, s, "job0", g0)
+		for d, l := range logs0 {
+			require.NotContains(t, l, cacheMissPrefix, "cold build should be quiet (vertex %s)", d)
+		}
+
+		// Rebuild: child seed unchanged (cache hit) but parent seed changed
+		// (miss). The child stays silent; the parent reports that all inputs
+		// were cached.
+		child1 := vtx(vtxOpt{name: "child1", cacheKeySeed: "c", value: "cv"})
+		parent1 := vtx(vtxOpt{
+			name: "parent1", cacheKeySeed: "p-CHANGED", value: "pv2",
+			inputs: []Edge{{Vertex: child1}},
+		})
+		_, logs1 := buildCapturingLogs(ctx, t, s, "job1", Edge{Vertex: parent1})
+		require.Contains(t, logs1[parent1.Digest()], cacheMissPrefix)
+		require.Contains(t, logs1[parent1.Digest()], "all inputs cached")
+		require.NotContains(t, logs1[child1.Digest()], cacheMissPrefix, "cached input should not report a miss")
+	})
+
+	t.Run("changed input is named", func(t *testing.T) {
+		t.Parallel()
+		s := NewSolver(SolverOpt{ResolveOpFunc: testOpResolver})
+		defer s.Close()
+
+		// Cold build of a 2-input parent.
+		g0 := Edge{Vertex: vtx(vtxOpt{
+			name: "p0", cacheKeySeed: "p", value: "pv",
+			inputs: []Edge{
+				{Vertex: vtx(vtxOpt{name: "a0", cacheKeySeed: "a", value: "av"})},
+				{Vertex: vtx(vtxOpt{name: "b0", cacheKeySeed: "b", value: "bv"})},
+			},
+		})}
+		buildCapturingLogs(ctx, t, s, "job0", g0)
+
+		// Rebuild: input "a" unchanged (cache hit), input "b" changed (rebuilt).
+		// Parent keeps its own seed, so the miss is attributable to input b.
+		parent1 := vtx(vtxOpt{
+			name: "p1", cacheKeySeed: "p", value: "pv",
+			inputs: []Edge{
+				{Vertex: vtx(vtxOpt{name: "a1", cacheKeySeed: "a", value: "av"})},
+				{Vertex: vtx(vtxOpt{name: "b1", cacheKeySeed: "b-CHANGED", value: "bv2"})},
+			},
+		})
+		_, logs1 := buildCapturingLogs(ctx, t, s, "job1", Edge{Vertex: parent1})
+		pl := logs1[parent1.Digest()]
+		require.Contains(t, pl, cacheMissPrefix)
+		require.Contains(t, pl, "rebuilt input(s)")
+		require.Contains(t, pl, "b1", "the changed input should be named")
+	})
+
+	t.Run("ignore cache is explained", func(t *testing.T) {
+		t.Parallel()
+		s := NewSolver(SolverOpt{ResolveOpFunc: testOpResolver})
+		defer s.Close()
+
+		g := Edge{Vertex: vtx(vtxOpt{name: "nc", cacheKeySeed: "x", value: "v", ignoreCache: true})}
+		_, logs := buildCapturingLogs(ctx, t, s, "job0", g)
+		require.Contains(t, logs[g.Vertex.Digest()], "--no-cache")
+	})
+}
+
+// TestCacheKeyDebug verifies that with BUILDKIT_CACHE_KEY_DEBUG enabled every
+// vertex emits its authoritative cache-key digest (the vertex→digest join), on
+// both the executed (miss) and cache-loaded (hit) paths, and that the digest
+// tracks the operation's cache seed.
+func TestCacheKeyDebug(t *testing.T) {
+	// Not parallel: toggles the package-level cacheKeyDebug flag.
+	cacheKeyDebug = true
+	defer func() { cacheKeyDebug = false }()
+
+	ctx := context.TODO()
+	s := NewSolver(SolverOpt{ResolveOpFunc: testOpResolver})
+	defer s.Close()
+
+	parentOp := digest.FromBytes([]byte("seed:pk")).String()
+
+	// Cold build: parent executes; its cache-key join is emitted.
+	child0 := vtx(vtxOpt{name: "ck-child0", cacheKeySeed: "ck", value: "cv"})
+	parent0 := vtx(vtxOpt{name: "ck-parent0", cacheKeySeed: "pk", value: "pv", inputs: []Edge{{Vertex: child0}}})
+	_, logs0 := buildCapturingLogs(ctx, t, s, "job0", Edge{Vertex: parent0})
+	require.Contains(t, logs0[parent0.Digest()], "[cache-key] vtx="+parent0.Digest().String()+" op="+parentOp,
+		"executed vertex should emit its authoritative cache key")
+
+	// Rebuild with identical seeds: parent is a cache hit, yet still emits the
+	// same join from the load-cache path (so tooling can diff run-over-run).
+	child1 := vtx(vtxOpt{name: "ck-child1", cacheKeySeed: "ck", value: "cv"})
+	parent1 := vtx(vtxOpt{name: "ck-parent1", cacheKeySeed: "pk", value: "pv", inputs: []Edge{{Vertex: child1}}})
+	_, logs1 := buildCapturingLogs(ctx, t, s, "job1", Edge{Vertex: parent1})
+	require.Contains(t, logs1[parent1.Digest()], "op="+parentOp,
+		"cache-hit vertex should still emit its authoritative cache key")
 }
 
 func newTrackingCacheManager(cm CacheManager) *trackingCacheManager {


### PR DESCRIPTION
## What

Two cooperating cache-miss diagnostics in the solver, both surfaced as ordinary **vertex log lines** — so they appear through the existing progress stream (`status.Logs`) with **zero client-side changes**.

### 1. Human-readable cache-miss reason (always on, boundary-gated)
At the exec-vs-load decision (`edge.execIfPossible`), the solver classifies *why* a step runs instead of loading from cache (`calcCacheMissReason`):

- `cache miss: rebuilt input(s): <names>` — a specific input rebuilt upstream
- `cache miss: all inputs cached but no matching result for this step (its definition changed, or this input combination is new)`
- `cache miss: cache disabled for this step (--no-cache)`

Cold builds stay **quiet** (nothing upstream was cached → no surprise → no noise).

### 2. Authoritative vertex→cache-key join (opt-in: `BUILDKIT_CACHE_KEY_DEBUG=1`)
The persisted cache is content-addressed and **vertex-agnostic** — `CacheKey.ID = rootKey(cacheMap.Digest, output)`, the LLB/vertex digest is in-memory only (`edge.go` `k.vtx = …`) and never stored. So nothing in the daemon (including the `--save-cache-debug` RPCs) can tell you *which vertex* produced a given digest.

This emits, per vertex, its cache-map digest on **both** the executed and cache-loaded paths:

```
[cache-key] vtx=sha256:… op=sha256:…
```

That `op` digest is the lookup key into the `--save-cache-debug` plaintext store. With it, external tooling (e.g. an Earthly-side consumer) can diff cache keys run-over-run and reverse-look-up the hashed inputs to explain *why* a step missed — the join that the cache itself deliberately doesn't keep.

### 3. Drive-by fix
`dgstTracker` is a package-global ring buffer mutated concurrently from `loadUnlocked` with no lock — a real data race in production (concurrent vertex loads), surfaced while testing. Guarded with a mutex.

## Why
Surfacing cache-miss reasons has been asked for since 2015 (moby/moby#9294, 18 comments, still open) and moby/buildkit#2567 (open, stalled). Upstream has shipped server-side trace logs (#4109), name-only client metrics (#4464), and post-hoc digest reverse-lookup (#6061) — but **no user-facing per-step reason**, and **no vertex→digest join** to drive tooling. This adds both, minimally.

## Scope / follow-ups
- Part 2 currently exposes the **op** cache-map digest. Dep (input) digests — needed to pinpoint *which file* in a COPY changed, the dominant moby/moby#9294 case — are the immediate next step.
- The reason gate uses `dep.cached`; switching to the cache-link signal (`dep.keyMap`) would also distinguish *evicted result* and *imported-cache miss*. Designed, not yet implemented.

## Test
- `TestCacheMissReason` — reason taxonomy + cold-build silence
- `TestCacheKeyDebug` — join emitted on both miss and hit paths with the correct digest
- Full `solver` suite green (excluding the pre-existing, environment-dependent `TestJobsIntegration`, which fails identically on `main`).