### PR TITLE
build: bake version.Package as github.com/EarthBuild/buildkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ FROM buildkit-base AS buildkit-version
 # TODO: PKG should be inferred from go modules
 ARG RELEASE_VERSION=v0.0.0+earthlyunknown
 RUN --mount=target=. \
-  PKG=github.com/moby/buildkit EARTHLY_PKG=github.com/earthly/buildkit VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags) REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi); \
+  PKG=github.com/moby/buildkit EARTHLY_PKG=github.com/EarthBuild/buildkit VERSION=$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags) REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi); \
   echo "-X ${PKG}/version.Version=${RELEASE_VERSION} -X ${PKG}/version.Revision=${REVISION} -X ${PKG}/version.Package=${EARTHLY_PKG}" | tee /tmp/.ldflags; \
   echo -n "${RELEASE_VERSION}" | tee /tmp/.version;
 


### PR DESCRIPTION
Fixes https://github.com/EarthBuild/earthbuild/issues/437

## Problem

The buildkitd/buildctl ldflags bake `version.Package` as the legacy `github.com/earthly/buildkit`:

```
buildkitd github.com/earthly/buildkit 485613cc c40c767e201de9ad72c8c52e207dc8f4b5b51e9d
```

EarthBuild's earthly client compares the buildkit daemon's reported package against `github.com/EarthBuild/buildkit` (case-insensitively) and, on mismatch, warns on every invocation:

```
Using a non-EarthBuild version of Buildkit is not supported.
  Supported: github.com/EarthBuild/buildkit
  Detected:  github.com/earthly/buildkit
```

## Fix

Set `EARTHLY_PKG=github.com/EarthBuild/buildkit` in the `buildkit-version` stage of the Dockerfile (the single source consumed by both the `buildctl` and `buildkitd` build stages, and by the Earthfile `+build` target via `FROM DOCKERFILE --target buildkit-linux`).

## Verification

Built `--target buildkit-linux` locally and confirmed:

```
$ buildkitd --version
buildkitd github.com/EarthBuild/buildkit v0.0.0-pkgtest .m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)