### PR TITLE
session/filesync: byte-level output progress, no ContentHasher (fixes AS LOCAL panic)

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -94,7 +94,7 @@ jobs:
             });
       -
         name: Build
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           provenance: false
           targets: integration-tests-base
@@ -164,7 +164,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build test image
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           provenance: false
           targets: integration-tests

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -88,7 +88,7 @@ jobs:
               core.setOutput('tags', JSON.stringify(matrix));
             });
             await core.group(`Set includes`, async () => {
-              const includes = yaml.load(core.getInput('includes'));
+              const includes = yaml.load(core.getInput('includes') || '[]');
               core.info(JSON.stringify(includes, null, 2));
               core.setOutput('includes', JSON.stringify(includes ?? []));
             });

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -43,7 +43,7 @@ jobs:
       -
         name: Platforms matrix
         id: platforms
-        uses: docker/bake-action/subaction/matrix@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           target: release
           fields: platforms
@@ -153,7 +153,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Run
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           targets: govulncheck
         env:

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -51,7 +51,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           provenance: false
           targets: binaries-for-test
@@ -273,7 +273,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           targets: integration-tests-base
           set: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
       -
         name: Generate matrix
         id: generate
-        uses: docker/bake-action/subaction/matrix@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           target: validate
           fields: platforms
@@ -80,7 +80,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Validate
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # v7.0.0
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           targets: ${{ matrix.target }}
           set: |

--- a/client/solve.go
+++ b/client/solve.go
@@ -65,7 +65,7 @@ type ExportEntry struct {
 	OutputDirFunc      func(map[string]string) (string, error)         // for ExporterEarthly
 	OutputPullCallback pullping.PullCallback                           // for ExporterEarthly
 	OutputStore        content.Store
-	OnReceiveProgress  func(int, bool) // earthly-specific: cumulative received-bytes callback (fsutil ProgressCb)
+	OnReceiveProgress  func(bytes int, done bool) // earthly-specific: cumulative received-bytes callback (fsutil ProgressCb)
 }
 
 type CacheOptionsEntry struct {

--- a/client/solve.go
+++ b/client/solve.go
@@ -65,7 +65,7 @@ type ExportEntry struct {
 	OutputDirFunc      func(map[string]string) (string, error)         // for ExporterEarthly
 	OutputPullCallback pullping.PullCallback                           // for ExporterEarthly
 	OutputStore        content.Store
-	OnReceiveFile      fsutil.ChangeFunc // earthly-specific: per-file callback for received export files
+	OnReceiveProgress  func(int, bool) // earthly-specific: cumulative received-bytes callback (fsutil ProgressCb)
 }
 
 type CacheOptionsEntry struct {
@@ -194,7 +194,7 @@ func (c *Client) solve(ctx context.Context, def *llb.Definition, runGateway runG
 					if ex.OutputPullCallback != nil {
 						s.Allow(pullping.NewPullPing(ex.OutputPullCallback))
 					}
-					s.Allow(filesync.NewFSSyncMultiTarget(ex.Output, ex.OutputDirFunc, ex.OnReceiveFile))
+					s.Allow(filesync.NewFSSyncMultiTarget(ex.Output, ex.OutputDirFunc, ex.OnReceiveProgress))
 				} else {
 					syncTargets = append(syncTargets, filesync.WithFSSync(exID, ex.Output))
 				}

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -110,7 +110,7 @@ func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress p
 	}))
 }
 
-func syncTargetDiffCopy(ds grpc.ServerStream, dest string, notifyFn fsutil.ChangeFunc) error {
+func syncTargetDiffCopy(ds grpc.ServerStream, dest string, progressFn func(int, bool)) error {
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		return errors.Wrapf(err, "failed to create synctarget dest dir %s", dest)
 	}
@@ -129,7 +129,14 @@ func syncTargetDiffCopy(ds grpc.ServerStream, dest string, notifyFn fsutil.Chang
 				return true
 			}
 		}(),
-		NotifyHashed: notifyFn,
+		// earthly-specific: byte-level received progress (cumulative), the
+		// non-hashing hook. The obvious per-file hook, NotifyHashed, forces a
+		// ContentHasher and MultiWriters every received byte through it for a
+		// digest nobody reads on this path - and left nil it is a nil-pointer
+		// panic, not a no-op (fsutil newHashWriter), which crashed
+		// SAVE ARTIFACT ... AS LOCAL. ProgressCb needs no hasher and gives live
+		// transfer feedback, which is what an output copy actually wants.
+		ProgressCb: progressFn,
 	}))
 }
 

--- a/session/filesync/diffcopy.go
+++ b/session/filesync/diffcopy.go
@@ -110,7 +110,7 @@ func recvDiffCopy(ds grpc.ClientStream, dest string, cu CacheUpdater, progress p
 	}))
 }
 
-func syncTargetDiffCopy(ds grpc.ServerStream, dest string, progressFn func(int, bool)) error {
+func syncTargetDiffCopy(ds grpc.ServerStream, dest string, progressFn func(bytes int, done bool)) error {
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		return errors.Wrapf(err, "failed to create synctarget dest dir %s", dest)
 	}

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -272,7 +272,7 @@ type earthlySyncTarget struct {
 	outdir     string
 	outdirFunc func(map[string]string) (string, error)
 	f          func(map[string]string) (io.WriteCloser, error)
-	progressFn func(int, bool)
+	progressFn func(bytes int, done bool)
 }
 
 func (sp *earthlySyncTarget) Register(server *grpc.Server) {

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -258,7 +258,7 @@ func NewFSSyncTargetDir(outdir string, progressFn func(bytes int, done bool)) se
 }
 
 // NewFSSyncMultiTarget allows writing into an io.WriteCloser; it is earthly-specific
-func NewFSSyncMultiTarget(f func(map[string]string) (io.WriteCloser, error), outdirFunc func(map[string]string) (string, error), progressFn func(int, bool)) session.Attachable {
+func NewFSSyncMultiTarget(f func(map[string]string) (io.WriteCloser, error), outdirFunc func(map[string]string) (string, error), progressFn func(bytes int, done bool)) session.Attachable {
 	p := &earthlySyncTarget{
 		f:          f,
 		outdirFunc: outdirFunc,

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -249,7 +249,7 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 
 // NewFSSyncTargetDir allows writing into a directory
 // earthly-specific: progressFn reports cumulative received bytes (fsutil ProgressCb)
-func NewFSSyncTargetDir(outdir string, progressFn func(int, bool)) session.Attachable {
+func NewFSSyncTargetDir(outdir string, progressFn func(bytes int, done bool)) session.Attachable {
 	p := &earthlySyncTarget{
 		outdir:     outdir,
 		progressFn: progressFn,

--- a/session/filesync/filesync.go
+++ b/session/filesync/filesync.go
@@ -248,31 +248,31 @@ func FSSync(ctx context.Context, c session.Caller, opt FSSendRequestOpt) error {
 }
 
 // NewFSSyncTargetDir allows writing into a directory
-// earthly-specific: notifyFn reports each received file (stock fsutil NotifyHashed)
-func NewFSSyncTargetDir(outdir string, notifyFn fsutil.ChangeFunc) session.Attachable {
+// earthly-specific: progressFn reports cumulative received bytes (fsutil ProgressCb)
+func NewFSSyncTargetDir(outdir string, progressFn func(int, bool)) session.Attachable {
 	p := &earthlySyncTarget{
-		outdir:   outdir,
-		notifyFn: notifyFn,
+		outdir:     outdir,
+		progressFn: progressFn,
 	}
 	return p
 }
 
 // NewFSSyncMultiTarget allows writing into an io.WriteCloser; it is earthly-specific
-func NewFSSyncMultiTarget(f func(map[string]string) (io.WriteCloser, error), outdirFunc func(map[string]string) (string, error), notifyFn fsutil.ChangeFunc) session.Attachable {
+func NewFSSyncMultiTarget(f func(map[string]string) (io.WriteCloser, error), outdirFunc func(map[string]string) (string, error), progressFn func(int, bool)) session.Attachable {
 	p := &earthlySyncTarget{
 		f:          f,
 		outdirFunc: outdirFunc,
-		notifyFn:   notifyFn,
+		progressFn: progressFn,
 	}
 	return p
 }
 
-// earthlySyncTarget is earthly-specific, supports a per-file notify callback and outdirFunc
+// earthlySyncTarget is earthly-specific: a byte-progress callback plus outdirFunc
 type earthlySyncTarget struct {
 	outdir     string
 	outdirFunc func(map[string]string) (string, error)
 	f          func(map[string]string) (io.WriteCloser, error)
-	notifyFn   fsutil.ChangeFunc
+	progressFn func(int, bool)
 }
 
 func (sp *earthlySyncTarget) Register(server *grpc.Server) {
@@ -281,7 +281,7 @@ func (sp *earthlySyncTarget) Register(server *grpc.Server) {
 
 func (sp *earthlySyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error) {
 	if sp.outdir != "" {
-		return syncTargetDiffCopy(stream, sp.outdir, sp.notifyFn)
+		return syncTargetDiffCopy(stream, sp.outdir, sp.progressFn)
 	}
 
 	opts, _ := metadata.FromIncomingContext(stream.Context())
@@ -297,7 +297,7 @@ func (sp *earthlySyncTarget) DiffCopy(stream FileSend_DiffCopyServer) (err error
 			return err
 		}
 		if outdir != "" {
-			return syncTargetDiffCopy(stream, outdir, sp.notifyFn)
+			return syncTargetDiffCopy(stream, outdir, sp.progressFn)
 		}
 	}
 	wc, err := sp.f(md)


### PR DESCRIPTION
syncTargetDiffCopy set NotifyHashed without a ContentHasher. fsutil wraps every incoming file in a hashedWriter whenever NotifyCb is set and DEREFERENCES the hasher to do it (diskwriter.go, newHashWriter), so a nil hasher is a nil-pointer panic, not a no-op - and `SAVE ARTIFACT ... AS LOCAL` crashed outright:

  panic: runtime error: invalid memory address or nil pointer dereference
  fsutil.newHashWriter(0x0, ...)   diskwriter.go:285

The session attachables run in the CLI, which is why it showed up there, not in buildkitd. Introduced by the verbose-progress rewire: the forked fsutil had a VerboseProgressCB hook that needed no hasher; stock fsutil offers only NotifyHashed, and the port adopted the hook without its precondition.

The real problem was the wrong hook. This is the OUTPUT path (writing built artifacts to the user's local disk); it computes no cache key and reads no digest - the callback was pure progress. But NotifyHashed is fsutil's HASHING per-file hook: it would MultiWriter every received byte through a hasher for a digest nobody reads, on every AS LOCAL, even once the nil-deref is fixed.

So switch to ReceiveOpt.ProgressCb: cumulative received bytes, per packet, NO hasher. It gives LIVE transfer feedback - which is what an output copy actually wants - and the panic is structurally impossible because no ContentHasher is ever constructed. The earthly-specific sync-target API carries a `func(int, bool)` progress callback instead of an `fsutil.ChangeFunc` (ExportEntry.OnReceiveFile -> OnReceiveProgress).

Not the Filter hook: it is an inclusion filter, applied in two places (receive.go destWalker + doubleWalkDiff) and sometimes with an empty stat, so it double-counts. Not a discard/no-op ContentHasher: it works, but it abuses the hashing hook for a non-hashing need. ProgressCb is the hook fsutil actually provides for this.

Trade-off: byte-level aggregate instead of per-file lines. On this path the per-file lines were VerbosePrintf (debug-only) anyway; the normal-level UX is a throttled byte summary, which ProgressCb feeds directly - and byte-level is the better signal for a slow network copy.

Verified: SAVE ARTIFACT AS LOCAL of a 60 MiB artifact succeeds, exact bytes on disk, live byte progress, no hashing. It panicked 100% of the time before.

Assisted-by: Claude:claude-opus-4.8 claude-code